### PR TITLE
new feature >> check "wp-config.php" location

### DIFF
--- a/admin/class-wp-security-bp-admin.php
+++ b/admin/class-wp-security-bp-admin.php
@@ -113,7 +113,7 @@ class WP_Security_BP_Admin {
 		*
 		* NOTE:  Alternative menu locations are available via WordPress administration menu functions.
 		*
-		*        Administration Menus: http://codex.wordpress.org/Administration_Menus
+		* Administration Menus: http://codex.wordpress.org/Administration_Menus
 		*
 		*/
 		add_options_page( 'WordPress Security Best Practices Dashboard', 'WP Security BP', 'manage_options', $this->plugin_name, array( $this, 'display_plugin_setup_page' )

--- a/admin/class-wp-security-bp-admin.php
+++ b/admin/class-wp-security-bp-admin.php
@@ -69,7 +69,7 @@ class WP_Security_BP_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_styles() {
+	public function enqueue_styles( $hook_suffix ) {
 
 		/**
 		 * This function is provided for demonstration purposes only.
@@ -82,8 +82,9 @@ class WP_Security_BP_Admin {
 		 * between the defined hooks and the functions defined in this
 		 * class.
 		 */
-
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/wp-security-bp-admin.css', array(), $this->version, 'all' );
+		if ( $hook_suffix === 'settings_page_wp-security-bp' ) {
+			wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/wp-security-bp-admin.css', array(), $this->version, 'all' );
+		}
 
 	}
 
@@ -92,7 +93,7 @@ class WP_Security_BP_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_scripts( $hook_suffix ) {
 
 		/**
 		 * This function is provided for demonstration purposes only.
@@ -105,9 +106,10 @@ class WP_Security_BP_Admin {
 		 * between the defined hooks and the functions defined in this
 		 * class.
 		 */
-
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/wp-security-bp-admin.js', array( 'jquery' ), $this->version, false );
-
+		if ( $hook_suffix === 'settings_page_wp-security-bp' ) {
+			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/wp-security-bp-admin.js', array( 'jquery' ), $this->version, false );
+		}
+		
 	}
 
 	/**

--- a/admin/class-wp-security-bp-admin.php
+++ b/admin/class-wp-security-bp-admin.php
@@ -41,6 +41,15 @@ class WP_Security_BP_Admin {
 	private $version;
 
 	/**
+	 * The 
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string    $admin_url    The url of this plugin.
+	 */
+	private $admin_url;
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
@@ -51,6 +60,7 @@ class WP_Security_BP_Admin {
 
 		$this->plugin_name = $plugin_name;
 		$this->version = $version;
+		$this->admin_url = admin_url( 'options-general.php?page=' . $this->plugin_name );
 
 	}
 
@@ -131,9 +141,22 @@ class WP_Security_BP_Admin {
 		*  Documentation : https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)
 		*/
 	$settings_link = array(
-		'<a href="' . admin_url( 'options-general.php?page=' . $this->plugin_name ) . '">' . __( 'Settings', $this->plugin_name ) . '</a>',
+		'<a href="' . $this->admin_url . '">' . __( 'Settings', $this->plugin_name ) . '</a>',
 	);
 	return array_merge( $settings_link, $links );
+
+	}
+
+	/**
+	 * This function fires the files test
+	 *
+	 * @since    1.0.0
+	 */
+
+	public function run_files_test() {
+		
+		$files = new WP_Security_BP_Files( $this->plugin_name, $this->admin_url );
+		$files->check_wp_config();
 
 	}
 

--- a/admin/js/wp-security-bp-admin.js
+++ b/admin/js/wp-security-bp-admin.js
@@ -29,4 +29,19 @@
 	 * practising this, we should strive to set a better example in our own work.
 	 */
 
+	jQuery(document).ready(function($) {
+
+		var data = {
+			'action': 'wp-security-bp',
+			'whatever': 1234
+		};
+
+		// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
+		jQuery.post(ajaxurl, data, function(response) {
+			console.log('Got this from the server: ' + JSON.stringify(response));
+		});
+	});
+
 })( jQuery );
+
+

--- a/admin/partials/wp-security-bp-admin-display.php
+++ b/admin/partials/wp-security-bp-admin-display.php
@@ -17,21 +17,5 @@
 <h1>WordPress Security Best Practices</h1>
 <?php
 
-$users = get_users( array( 'include' => array( 2, 3 ) ) );
-foreach ( $users as $user ) {
-    if ( true ) {
-        //var_dump( $user );
-    }
-}
-
-add_action( 'admin_notices', 'caca');
-
-function caca() {
-    $class = 'notice notice-error';
-    $message = __( 'Irks! An error has occurred.', 'sample-text-domain' );
-
-    printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) ); 
-}
-
 $plugin_name = 'wp-security-bp';
 $files = new WP_Security_BP_Files( $plugin_name, admin_url( 'options-general.php?page=' . $plugin_name ) );

--- a/admin/partials/wp-security-bp-admin-display.php
+++ b/admin/partials/wp-security-bp-admin-display.php
@@ -23,3 +23,6 @@ foreach ( $users as $user ) {
         var_dump( $user );
     }
 }
+
+$plugin_name = 'wp-security-bp';
+$files = new WP_Security_BP_Files( $plugin_name, admin_url( 'options-general.php?page=' . $plugin_name ) );

--- a/admin/partials/wp-security-bp-admin-display.php
+++ b/admin/partials/wp-security-bp-admin-display.php
@@ -17,5 +17,5 @@
 <h1>WordPress Security Best Practices</h1>
 <?php
 
-$plugin_name = 'wp-security-bp';
-$files = new WP_Security_BP_Files( $plugin_name, admin_url( 'options-general.php?page=' . $plugin_name ) );
+/* $plugin_name = 'wp-security-bp';
+$files = new WP_Security_BP_Files( $plugin_name, admin_url( 'options-general.php?page=' . $plugin_name ) ); */

--- a/admin/partials/wp-security-bp-admin-display.php
+++ b/admin/partials/wp-security-bp-admin-display.php
@@ -14,14 +14,23 @@
 ?>
 
 <!-- This file should primarily consist of HTML with a little bit of PHP. -->
-<h1>OLAKEASE</h1>
+<h1>WordPress Security Best Practices</h1>
 <?php
 
 $users = get_users( array( 'include' => array( 2, 3 ) ) );
 foreach ( $users as $user ) {
     if ( true ) {
-        var_dump( $user );
+        //var_dump( $user );
     }
+}
+
+add_action( 'admin_notices', 'caca');
+
+function caca() {
+    $class = 'notice notice-error';
+    $message = __( 'Irks! An error has occurred.', 'sample-text-domain' );
+
+    printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) ); 
 }
 
 $plugin_name = 'wp-security-bp';

--- a/includes/class-wp-security-bp-files.php
+++ b/includes/class-wp-security-bp-files.php
@@ -97,6 +97,15 @@ class WP_Security_BP_Files {
 	protected $parent_root;
 
 	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      array    $json    The array that will be passed as a JSON file to the admin
+	 */
+	protected $json;
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
@@ -109,6 +118,12 @@ class WP_Security_BP_Files {
 		$this->request_uri = $request_uri;
 		$this->nonce_action_name = 'wp-security-bp-file-access';
 		$this->wp_config = 'wp-config.php';
+		$this->json = array(
+			'status'   => 'fail',
+			'message'  => '',
+			'button'   => false,
+			'uri'      => '',
+		);
 
 		$access_type = get_filesystem_method();
 		if ( $access_type === 'direct' ) {
@@ -137,21 +152,17 @@ class WP_Security_BP_Files {
 			$this->parent_root = trailingslashit( dirname( $this->root ) );
 
 			// get the plugin directory path
-			$plugin_path = trailingslashit( $wp_filesystem->wp_plugins_dir() . $plugin_name );
+			$plugin_path = trailingslashit( $this->wp_filesystem->wp_plugins_dir() . $this->plugin_name );
 
 			// make a directory
-			$wp_filesystem->mkdir( $plugin_path. 'test-folder' );
+			$this->wp_filesystem->mkdir( $plugin_path. 'test-folder' );
 
 			// make a file and write content
-			$wp_filesystem->put_contents(
+			$this->wp_filesystem->put_contents(
 				$plugin_path . 'test-folder/test-file.txt',
 				'Example contents of a file',
 				FS_CHMOD_FILE // predefined mode settings for WP files
 			);
-
-			$wp_config_path = $this->find_wp_config();
-
-			echo $wp_config_path;
 		
 		}	
 		else {
@@ -189,14 +200,50 @@ class WP_Security_BP_Files {
 	private function find_wp_config() {
 
 		if ( $this->wp_filesystem->exists( $this->root . $this->wp_config ) ) {
-			return $this->root;
-		}
-		elseif ( $this->wp_filesystem->exists( $this->parent_root . $this->wp_config ) ) {
-			return $this->parent_root;
+			return true;
 		}
 		else {
 			return false;
 		}
+
+	}
+
+	/**
+	 * Short desc
+	 *
+	 * Long desc
+	 *
+	 * @since    1.0.0
+	 * @access   public
+	 */
+	public function check_wp_config() {
+
+		$is_in_root = $this->find_wp_config();
+		
+		if ( $is_in_root ) {
+			$this->json['message'] = __( 'Very bad guy', $this->plugin_name );
+			$this->json['button'] = true;
+			$this->json['uri'] = 'url-to-fix';
+		}
+		else {
+			$this->json['status'] = 'passed';
+			$this->json['message'] = __( 'Good job!!!', $this->plugin_name );
+		}
+
+		wp_send_json( (object) $this->json );
+		wp_die();
+
+	}
+
+	/**
+	 * Short desc
+	 *
+	 * Long desc
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function move_wp_config() {
 
 		/*
 		//$file = 'wp-config.php';
@@ -215,21 +262,5 @@ class WP_Security_BP_Files {
 		*/
 
 	}
-
-	/**
-	 * Short desc
-	 *
-	 * Long desc
-	 *
-	 * @since    1.0.0
-	 * @access   private
-	 */
-	private function evaluate_wp_config_path() {
-
-		
-
-	}
-
-	
 
 }

--- a/includes/class-wp-security-bp-files.php
+++ b/includes/class-wp-security-bp-files.php
@@ -85,22 +85,24 @@ class WP_Security_BP_Files {
 			global $wp_filesystem;
 
 			// get the plugin directory path
-			$path = trailingslashit( $wp_filesystem->wp_plugins_dir() . $plugin_name );
+			$plugin_path = trailingslashit( $wp_filesystem->wp_plugins_dir() . $plugin_name );
 
 			// make a directory
-			$wp_filesystem->mkdir( $path. 'test-folder' );
+			$wp_filesystem->mkdir( $plugin_path. 'test-folder' );
 
 			// make a file and write content
 			$wp_filesystem->put_contents(
-				$path . 'test-folder/test-file.txt',
+				$plugin_path . 'test-folder/test-file.txt',
 				'Example contents of a file',
 				FS_CHMOD_FILE // predefined mode settings for WP files
 			);
+
+			$this->find_wp_config( $wp_filesystem );
 		
 		}	
 		else {
 			/* don't have direct write access. Prompt user with our notice */
-			echo "don't have direct write access. Prompt user with our notice";
+			echo "You don't have direct write access :(";
 		}
 
 
@@ -130,9 +132,22 @@ class WP_Security_BP_Files {
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function load_dependencies() {
+	private function find_wp_config( $wp_filesystem ) {
 
-		
+		//$file = 'wp-config.php';
+		$file = 'test-file.txt';
+
+		$root = get_home_path();
+		$defaul_path = $wp_filesystem->wp_content_dir();
+		if ( $wp_filesystem->exists( $root . $file ) ) {
+			$parent_root = trailingslashit( dirname( $root ) );
+			$wp_filesystem->move(
+				$root . $file,
+				$parent_root . $file,
+				true // Overwrites if exists
+			);
+		}
+
 	}
 
 	

--- a/includes/class-wp-security-bp-files.php
+++ b/includes/class-wp-security-bp-files.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * The file that defines the Files class
+ *
+ * This class handles all the files access to read and write.
+ *
+ * @link       http://example.com
+ * @since      1.0.0
+ *
+ * @package    wp_security_bp
+ * @subpackage wp_security_bp/includes
+ */
+
+/**
+ * The Files class.
+ *
+ * This class handles all the files access to read and write.
+ *
+ * @since      1.0.0
+ * @package    wp_security_bp
+ * @subpackage wp_security_bp/includes
+ * @author     Cyan Lovers <hello@cyanlove.com>
+ */
+class WP_Security_BP_Files {
+
+	/**
+	 * The unique identifier of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $plugin_name    The string used to uniquely identify this plugin.
+	 */
+	protected $plugin_name;
+
+	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $request_uri    The URI where the request is made from
+	 */
+	protected $request_uri;
+
+	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $nonce_action_name    The action for the nonce creation
+	 */
+	protected $nonce_action_name;
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @since    1.0.0
+	 * @param    string    $plugin_name       The name of this plugin.
+	 * @param    string    $request_uri       The URI from the request is made.
+	 */
+	public function __construct( $plugin_name, $request_uri ) {
+
+		$this->plugin_name = $plugin_name;
+		$this->request_uri = $request_uri;
+		$this->nonce_action_name = 'wp-security-bp-file-access';
+
+		// request credentials
+		$creds = $this->request_credentials();
+
+		if ( false === $creds ) {
+			return; // stop processing here
+		}
+
+		var_dump($creds);
+
+		echo 'olakeasetu';
+
+
+
+	}
+
+	/**
+	 * Short desc
+	 *
+	 * Long desc
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function request_credentials() {
+
+		$url = wp_nonce_url( $this->request_uri, $this->nonce_action_name );
+		return request_filesystem_credentials( $url, '', false, false, null );
+
+	}
+
+	/**
+	 * Short desc
+	 *
+	 * Long desc
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function load_dependencies() {
+
+		
+	}
+
+	
+
+}

--- a/includes/class-wp-security-bp-files.php
+++ b/includes/class-wp-security-bp-files.php
@@ -52,6 +52,51 @@ class WP_Security_BP_Files {
 	protected $nonce_action_name;
 
 	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $wp_config    The name of the file wp-config.php
+	 */
+	protected $wp_config;
+
+	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $htaccess    The name of the file .htaccess
+	 */
+	protected $htaccess;
+
+	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      object    $wp_filesystem    The Object $wp_filesystem
+	 */
+	protected $wp_filesystem;
+
+	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $root    The uri of the installation root
+	 */
+	protected $root;
+
+	/**
+	 * Short desc
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $parent_root    The uri of the parent installation root
+	 */
+	protected $parent_root;
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
@@ -63,6 +108,7 @@ class WP_Security_BP_Files {
 		$this->plugin_name = $plugin_name;
 		$this->request_uri = $request_uri;
 		$this->nonce_action_name = 'wp-security-bp-file-access';
+		$this->wp_config = 'wp-config.php';
 
 		$access_type = get_filesystem_method();
 		if ( $access_type === 'direct' ) {
@@ -83,6 +129,12 @@ class WP_Security_BP_Files {
 
 			// call global $wp_filesystem variable
 			global $wp_filesystem;
+			$this->wp_filesystem = $wp_filesystem;
+
+			// define root dir
+			$this->root = $wp_filesystem->abspath();
+			// define parent root dir
+			$this->parent_root = trailingslashit( dirname( $this->root ) );
 
 			// get the plugin directory path
 			$plugin_path = trailingslashit( $wp_filesystem->wp_plugins_dir() . $plugin_name );
@@ -97,7 +149,9 @@ class WP_Security_BP_Files {
 				FS_CHMOD_FILE // predefined mode settings for WP files
 			);
 
-			$this->find_wp_config( $wp_filesystem );
+			$wp_config_path = $this->find_wp_config();
+
+			echo $wp_config_path;
 		
 		}	
 		else {
@@ -132,12 +186,23 @@ class WP_Security_BP_Files {
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function find_wp_config( $wp_filesystem ) {
+	private function find_wp_config() {
 
+		if ( $this->wp_filesystem->exists( $this->root . $this->wp_config ) ) {
+			return $this->root;
+		}
+		elseif ( $this->wp_filesystem->exists( $this->parent_root . $this->wp_config ) ) {
+			return $this->parent_root;
+		}
+		else {
+			return false;
+		}
+
+		/*
 		//$file = 'wp-config.php';
 		$file = 'test-file.txt';
 
-		$root = get_home_path();
+		$root = $wp_filesystem->abspath();
 		$defaul_path = $wp_filesystem->wp_content_dir();
 		if ( $wp_filesystem->exists( $root . $file ) ) {
 			$parent_root = trailingslashit( dirname( $root ) );
@@ -147,6 +212,21 @@ class WP_Security_BP_Files {
 				true // Overwrites if exists
 			);
 		}
+		*/
+
+	}
+
+	/**
+	 * Short desc
+	 *
+	 * Long desc
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function evaluate_wp_config_path() {
+
+		
 
 	}
 

--- a/includes/class-wp-security-bp-files.php
+++ b/includes/class-wp-security-bp-files.php
@@ -155,14 +155,14 @@ class WP_Security_BP_Files {
 			$plugin_path = trailingslashit( $this->wp_filesystem->wp_plugins_dir() . $this->plugin_name );
 
 			// make a directory
-			$this->wp_filesystem->mkdir( $plugin_path. 'test-folder' );
+			//$this->wp_filesystem->mkdir( $plugin_path . 'test-folder' );
 
 			// make a file and write content
-			$this->wp_filesystem->put_contents(
+			/* $this->wp_filesystem->put_contents(
 				$plugin_path . 'test-folder/test-file.txt',
 				'Example contents of a file',
 				FS_CHMOD_FILE // predefined mode settings for WP files
-			);
+			); */
 		
 		}	
 		else {
@@ -230,7 +230,7 @@ class WP_Security_BP_Files {
 			$this->json['message'] = __( 'Good job!!!', $this->plugin_name );
 		}
 
-		wp_send_json( (object) $this->json );
+		wp_send_json( $this->json );
 		wp_die();
 
 	}

--- a/includes/class-wp-security-bp.php
+++ b/includes/class-wp-security-bp.php
@@ -169,6 +169,9 @@ class WP_Security_BP {
 		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . $this->plugin_name . '.php' );
 		$this->loader->add_filter( 'plugin_action_links_' . $plugin_basename, $plugin_admin, 'add_action_links' );
 
+		// Run files test
+		$this->loader->add_action( 'wp_ajax_' . $this->plugin_name, $plugin_admin, 'run_files_test' );
+
 	}
 
 	/**

--- a/includes/class-wp-security-bp.php
+++ b/includes/class-wp-security-bp.php
@@ -112,6 +112,11 @@ class WP_Security_BP {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wp-security-bp-i18n.php';
 
 		/**
+		 * The class responsible for reading and writing files.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wp-security-bp-files.php';
+
+		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-wp-security-bp-admin.php';

--- a/includes/class-wp-security-bp.php
+++ b/includes/class-wp-security-bp.php
@@ -170,7 +170,9 @@ class WP_Security_BP {
 		$this->loader->add_filter( 'plugin_action_links_' . $plugin_basename, $plugin_admin, 'add_action_links' );
 
 		// Run files test
-		$this->loader->add_action( 'wp_ajax_' . $this->plugin_name, $plugin_admin, 'run_files_test' );
+		if ( wp_doing_ajax() ) {
+			$this->loader->add_action( 'wp_ajax_' . $this->plugin_name, $plugin_admin, 'run_files_test' );
+		}
 
 	}
 


### PR DESCRIPTION
I have created the new class `WP_Security_BP_Files` and two methods that check if `wp-config.php` is on default place and return a JSON object. The method is requested through basic ajax request made with jQuery and response is shown in the console.

1. Pull the branch locally and go to plugin page on the admin.
2. Then check the console to see the response.
3. Try to move the `wp-config.php` file to the parent folder and check again to see if the response changes.

**The workflow is as follows:**

1. Create a class with all necessary properties and methods.
2. The method that evaluates the feature should return a JSON with the WP function `wp_send_json()` and then die with `wp_die()`
3. In `WP_Security_BP_Admin` there is a method that instantiates the class and calls the evaluate method of this class.
4. In `WP_Security_BP` it must be loaded the action that hooks this method in the appropriate WP hook. This happens in `define_admin_hooks()` method.
5. On the JS file we have to make an ajax request with the global variable `ajaxurl` and the proper `action` value as you can see on the file I've done.

Enjoy! 😃 